### PR TITLE
Fix port and credentials for PostgreSQL

### DIFF
--- a/.env
+++ b/.env
@@ -34,7 +34,7 @@ MESSENGER_TRANSPORT_DSN=doctrine://default
 #
 # DATABASE_URL="sqlite:///%kernel.project_dir%/var/data.db"
 # DATABASE_URL="mysql://db_user:db_password@127.0.0.1:3306/db_name?serverVersion=5.7"
-DATABASE_URL="postgresql://db_user:db_password@127.0.0.1:5432/db_name?serverVersion=13&charset=utf8"
+DATABASE_URL="postgresql://symfony:ChangeMe@127.0.0.1:5432/app?serverVersion=13&charset=utf8"
 ###< doctrine/doctrine-bundle ###
 
 ###> symfony/messenger ###

--- a/docker-compose.override.yaml
+++ b/docker-compose.override.yaml
@@ -14,7 +14,7 @@ services:
 ###> doctrine/doctrine-bundle ###
   database:
     ports:
-      - "5432"
+      - "5432:5432"
 ###< doctrine/doctrine-bundle ###
 
 ###> symfony/mailer ###


### PR DESCRIPTION
## PostgreSQL port on Docker
Exposes port `5432` on the host by default, so that one can start their app using Symfony CLI webserver + Docker

## Credentials
Ensure that they match the ones defined by default in `docker-compose.yaml`, so that it works right away locally.