### PR TITLE
Fix code blocks background systems using a dark appearance

### DIFF
--- a/templates/welcome/index.html.twig
+++ b/templates/welcome/index.html.twig
@@ -9,6 +9,7 @@
             --text-color: #3f3f46;
             --link-color: #2563eb;
             --logo-separator-color: #d4d4d8;
+            --code-background: #eee;
         }
         @media (prefers-color-scheme: dark) {
             :root {
@@ -16,6 +17,7 @@
                 --text-color: #e4e4e7;
                 --link-color: #60a5fa;
                 --logo-separator-color: #71717a;
+                --code-background: #111;
             }
         }
         body {
@@ -36,12 +38,11 @@
         .welcome-wrapper .platformsh-logo .platformsh-logo-brandmark,
         .welcome-wrapper .platformsh-logo .platformsh-logo-wordmark { fill: var(--text-color); }
         .welcome-wrapper h1 { font-size: 21px; line-height: 1.2; margin-bottom: 1.5rem; }
-        .welcome-wrapper h1 svg { background: #059669; color: #fff; margin: 0 1rem 0 0; padding: 0.25rem; }
         .welcome-wrapper ul { padding-left: 1.5rem; }
         .welcome-wrapper li { margin-top: .5rem; }
         .welcome-wrapper a { color: var(--link-color); text-decoration: none; }
         .welcome-wrapper a:hover { text-decoration: underline; }
-        .welcome-wrapper code { background-color: #eee; padding: 0.2rem 0.4rem; }
+        .welcome-wrapper code { background-color: var(--code-background); padding: 0.2rem 0.4rem; }
         @media (min-width: 992px) {
             .welcome-wrapper { margin: 3rem; }
             .welcome-wrapper h1 { font-size: 24px; letter-spacing: -0.01rem; }


### PR DESCRIPTION
Use a CSS variable for the code block background color to be able to change it in dark mode since the clear one is very close to the text color on dark mode


Also, strip an unused CSS line

| Before | After |
|--------|------|
| ![before](https://user-images.githubusercontent.com/7191841/194339212-a6085c7c-256c-4cde-882b-0ddcc2a64dd0.png) | ![after](https://user-images.githubusercontent.com/7191841/194339372-ec997f16-ab2d-412b-b8de-9c254d80a8ff.png) |