### PR TITLE
Use a relative path for opcache preloading

### DIFF
--- a/.platform.app.yaml
+++ b/.platform.app.yaml
@@ -16,11 +16,11 @@ runtime:
         - pdo_pgsql
         - sodium
         - xsl
-        
 
 variables:
     php:
-        opcache.preload: /app/config/preload.php
+        opcache.preload: config/preload.php
+
 build:
     flavor: none
 
@@ -35,17 +35,16 @@ web:
 
 mounts:
     "/var": { source: local, source_path: var }
-    
 
 relationships:
     database: "database:postgresql"
-    
+
 hooks:
     build: |
         set -x -e
 
         curl -fs https://get.symfony.com/cloud/configurator | bash
-        
+
         symfony-build
 
     deploy: |


### PR DESCRIPTION
The opcache.preload value is evaluated relative to the app root, so this will still work. It also removes the need for the app to be mounted on `/app` (which, while true on platform standard, is incorrect on Dedicated Gen2, and prevents the app from starting).

https://docs.platform.sh/languages/php.html#opcache-preloading

+ Formatting fixes