### PR TITLE
Update .platform.app.yaml

### DIFF
--- a/.platform.app.yaml
+++ b/.platform.app.yaml
@@ -62,6 +62,8 @@ crons:
 
 workers:
     messenger:
+        disk: 256
+        size: 'S'
         commands:
             # Consume "async" messages (as configured in the routing section of config/packages/messenger.yaml)
             start: symfony console --time-limit=3600 --memory-limit=64M messenger:consume async


### PR DESCRIPTION
@fabpot 
adding `disk` and `size` seems to be a best practice to avoid inherit a disk size of 1024 and so, exceeds plan subscription limits in some case. 
related to slack discussion: https://platformsh.slack.com/archives/CEDK8KCSC/p1667568389116509?thread_ts=1667497077.851249&cid=CEDK8KCSC
and doc : https://docs.platform.sh/create-apps/workers.html#inheritance